### PR TITLE
 refactor: centralizar autenticación en AuthContext con hook useAuth

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,6 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
-import { useState, useEffect } from 'react';
+import { AuthProvider } from './context/AuthContext';
+import { useAuth } from './context/useAuth';
 import Navbar from './components/Navbar';
 import Home from './views/Home';
 import Buscador from './views/Buscador';
@@ -13,83 +14,21 @@ import AdminPanel from './views/AdminPanel';
 import AdminProducts from './views/AdminProducts';
 import ProductForm from './views/ProductForm';
 
-function App() {
-  // Estado para saber si el usuario tiene sesión
-  const [isAuth, setIsAuth] = useState(!!localStorage.getItem('token'));
-  const rol = localStorage.getItem('rol');
-  const isAdmin = isAuth && (rol === 'tienda' || rol === 'admin');
-  // Estado para mostrar el mensaje de sesión expirada
-  const [showExpiredModal, setShowExpiredModal] = useState(false);
-
-  // Reconexión: verificar si la sesión sigue válida al volver a estar online
-  useEffect(() => {
-    const handleOnline = async () => {
-      const token = localStorage.getItem('token');
-      if (!token) return;
-
-      try {
-        const res = await fetch(`${import.meta.env.VITE_API_URL}/auth/verify`, {
-          headers: { Authorization: `Bearer ${token}` },
-        });
-
-        if (!res.ok) {
-          localStorage.removeItem('token');
-          setIsAuth(false);
-          setShowExpiredModal(true);
-        }
-      } catch {
-        // Sin conexión aún, no hacer nada
-      }
-    };
-
-    window.addEventListener('online', handleOnline);
-    return () => window.removeEventListener('online', handleOnline);
-  }, []);
-
-  // Checador de pestañas (Storage Event)
-  useEffect(() => {
-    const handleStorageChange = (e) => {
-      // Si otra pestaña borró el token (Logout o Expiración)
-      if (e.key === 'token' && e.newValue === null) {
-        setIsAuth(false);
-        setShowExpiredModal(true); // Mostramos el mensaje de que terminó
-      }
-      // Si otra pestaña inició sesión
-      if (e.key === 'token' && e.newValue !== null) {
-        setIsAuth(true);
-        setShowExpiredModal(false);
-      }
-    };
-
-    window.addEventListener('storage', handleStorageChange);
-    return () => window.removeEventListener('storage', handleStorageChange);
-  }, []);
-
-  // Función para cerrar sesión
-  const handleLogout = () => {
-    localStorage.removeItem('token'); // Borramos el token
-    setIsAuth(false);
-    // Se envia un evento manual por si necesitamos que esta misma pestaña reaccione
-    window.dispatchEvent(new Event('storage')); 
-  };
+function AppRoutes() {
+  const { isAuth, isAdmin, setShowExpiredModal, showExpiredModal } = useAuth();
 
   return (
     <div className="min-h-screen bg-[#0a0a0a]">
-      {/* Pasamos los props al Navbar */}
-      <Navbar isAuth={isAuth} isAdmin={isAdmin} handleLogout={handleLogout} />
-      
+      <Navbar />
+
       <main>
         <Routes>
           <Route path="/" element={<Home />} />
-          <Route
-            path="/buscador"
-            element={isAuth ? <Buscador /> : <Navigate to="/login" replace />}
-          />
-          {/* Le pasamos setIsAuth al Login para que pueda avisar cuando entre */}
-          <Route path="/blog" element={<Blog isAuth={isAuth} />} />
+          <Route path="/buscador" element={isAuth ? <Buscador /> : <Navigate to="/login" replace />} />
+          <Route path="/blog" element={<Blog />} />
           <Route path="/blog/crear" element={isAuth ? <CreatePost /> : <Navigate to="/login" replace />} />
           <Route path="/blog/editar/:id" element={isAuth ? <EditPost /> : <Navigate to="/login" replace />} />
-          <Route path="/login" element={<Login setIsAuth={setIsAuth} />} />
+          <Route path="/login" element={<Login />} />
           <Route path="/forgot-password" element={<ForgotPassword />} />
           <Route path="/reset-password" element={<ResetPassword />} />
           <Route path="/admin" element={isAdmin ? <AdminPanel /> : <Navigate to="/" replace />} />
@@ -105,7 +44,7 @@ function App() {
           <div className="bg-[#0a0a0a] border-2 border-neutral-800 p-8 rounded-2xl max-w-sm w-full text-center shadow-[0_0_30px_rgba(16,185,129,0.15)] animate-scale-in">
             <h3 className="text-emerald-400 text-xl font-bold mb-4 tracking-widest">SESIÓN TERMINADA</h3>
             <p className="text-gray-400 mb-6">Tu sesión ha expirado o fue cerrada en otra pestaña.</p>
-            <button 
+            <button
               onClick={() => setShowExpiredModal(false)}
               className="w-full text-gray-900 bg-emerald-500 hover:bg-emerald-400 font-bold tracking-widest px-6 py-3 rounded-xl transition-all outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0a] focus-visible:ring-emerald-500"
             >
@@ -115,6 +54,14 @@ function App() {
         </div>
       )}
     </div>
+  );
+}
+
+function App() {
+  return (
+    <AuthProvider>
+      <AppRoutes />
+    </AuthProvider>
   );
 }
 

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,7 +1,9 @@
 import { NavLink } from 'react-router-dom';
+import { useAuth } from '../context/useAuth';
 
-// NUEVO: Recibimos las props isAuth y handleLogout
-const Navbar = ({ isAuth, isAdmin, handleLogout }) => {
+const Navbar = () => {
+  const { isAuth, isAdmin, logout } = useAuth();
+
   const linkBase = "text-xl font-bold tracking-widest transition-all duration-300 px-10 py-5 rounded-2xl flex items-center justify-center outline-none";
   const activeClass = "text-emerald-400 bg-neutral-800/50 border-2 border-emerald-500/50 shadow-[0_0_20px_rgba(16,185,129,0.1)]";
   const inactiveClass = "text-gray-400 hover:text-emerald-400 hover:bg-neutral-800/30 border-2 border-transparent";
@@ -9,49 +11,34 @@ const Navbar = ({ isAuth, isAdmin, handleLogout }) => {
   return (
     <nav className="w-full bg-[#0a0a0a] border-b border-neutral-800 sticky top-0 z-50 h-28 flex items-center">
       <div className="w-full px-20 flex items-center justify-around">
-        
-        <NavLink
-          to="/"
-          className={({ isActive }) => `${linkBase} ${isActive ? activeClass : inactiveClass}`}
-        >
+
+        <NavLink to="/" className={({ isActive }) => `${linkBase} ${isActive ? activeClass : inactiveClass}`}>
           HOME
         </NavLink>
 
-        <NavLink
-          to="/buscador"
-          className={({ isActive }) => `${linkBase} ${isActive ? activeClass : inactiveClass}`}
-        >
+        <NavLink to="/buscador" className={({ isActive }) => `${linkBase} ${isActive ? activeClass : inactiveClass}`}>
           BUSCADOR
         </NavLink>
 
-        <NavLink
-          to="/blog"
-          className={({ isActive }) => `${linkBase} ${isActive ? activeClass : inactiveClass}`}
-        >
+        <NavLink to="/blog" className={({ isActive }) => `${linkBase} ${isActive ? activeClass : inactiveClass}`}>
           BLOG
         </NavLink>
 
         {isAdmin && (
-          <NavLink
-            to="/admin"
-            className={({ isActive }) => `${linkBase} ${isActive ? activeClass : inactiveClass}`}
-          >
+          <NavLink to="/admin" className={({ isActive }) => `${linkBase} ${isActive ? activeClass : inactiveClass}`}>
             ADMIN
           </NavLink>
         )}
 
         {isAuth ? (
           <button
-            onClick={handleLogout}
+            onClick={logout}
             className={`${linkBase} text-gray-400 hover:text-red-400 hover:bg-neutral-800/30 border-2 border-transparent cursor-pointer`}
           >
             LOGOUT
           </button>
         ) : (
-          <NavLink
-            to="/login"
-            className={({ isActive }) => `${linkBase} ${isActive ? activeClass : inactiveClass}`}
-          >
+          <NavLink to="/login" className={({ isActive }) => `${linkBase} ${isActive ? activeClass : inactiveClass}`}>
             LOGIN
           </NavLink>
         )}

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,0 +1,69 @@
+import { createContext, useState, useEffect } from 'react';
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const AuthContext = createContext(null);
+
+export function AuthProvider({ children }) {
+  const [isAuth, setIsAuth] = useState(!!localStorage.getItem('token'));
+  const [rol, setRol] = useState(localStorage.getItem('rol') || '');
+  const [showExpiredModal, setShowExpiredModal] = useState(false);
+
+  const isAdmin = isAuth && (rol === 'tienda' || rol === 'admin');
+
+  const login = (token, userRol) => {
+    localStorage.setItem('token', token);
+    localStorage.setItem('rol', userRol);
+    setIsAuth(true);
+    setRol(userRol);
+  };
+
+  const logout = () => {
+    localStorage.removeItem('token');
+    localStorage.removeItem('rol');
+    setIsAuth(false);
+    setRol('');
+    window.dispatchEvent(new Event('storage'));
+  };
+
+  useEffect(() => {
+    const handleOnline = async () => {
+      const token = localStorage.getItem('token');
+      if (!token) return;
+      try {
+        const res = await fetch(`${import.meta.env.VITE_API_URL}/auth/verify`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!res.ok) {
+          logout();
+          setShowExpiredModal(true);
+        }
+      } catch {
+        // Sin conexión aún
+      }
+    };
+    window.addEventListener('online', handleOnline);
+    return () => window.removeEventListener('online', handleOnline);
+  }, []);
+
+  useEffect(() => {
+    const handleStorage = (e) => {
+      if (e.key === 'token' && e.newValue === null) {
+        setIsAuth(false);
+        setRol('');
+        setShowExpiredModal(true);
+      }
+      if (e.key === 'token' && e.newValue !== null) {
+        setIsAuth(true);
+        setShowExpiredModal(false);
+      }
+    };
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ isAuth, isAdmin, login, logout, showExpiredModal, setShowExpiredModal }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/frontend/src/context/useAuth.js
+++ b/frontend/src/context/useAuth.js
@@ -1,0 +1,6 @@
+import { useContext } from 'react';
+import { AuthContext } from './AuthContext';
+
+export function useAuth() {
+  return useContext(AuthContext);
+}

--- a/frontend/src/views/Blog.jsx
+++ b/frontend/src/views/Blog.jsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { useState } from 'react';
+import { useAuth } from '../context/useAuth';
 
 const postsMock = [
   {
@@ -25,7 +26,8 @@ const postsMock = [
   },
 ];
 
-export default function Blog({ isAuth }) {
+export default function Blog() {
+  const { isAuth } = useAuth();
   const [posts, setPosts] = useState(postsMock);
 
   const handleEliminar = (id) => {

--- a/frontend/src/views/Login.jsx
+++ b/frontend/src/views/Login.jsx
@@ -1,7 +1,10 @@
 import { useState, useRef } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/useAuth';
 
-export default function Login({ setIsAuth }) {
+export default function Login() {
+  const { login } = useAuth();
+  const navigate = useNavigate();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [status, setStatus] = useState('idle'); // idle | loading | success | error
@@ -77,15 +80,9 @@ export default function Login({ setIsAuth }) {
         return;
       }
 
-      // Guardamos la sesión real
-      localStorage.setItem('token', data.token);
-      localStorage.setItem('rol', data.user.rol);
+      login(data.token, data.user.rol);
       setStatus('success');
-      
-      // pruebas
-      setIsAuth(true);
-      
-      alert(`¡Login exitoso! Bienvenido, ${data.user.rol}.`);
+      navigate(data.user.rol === 'admin' ? '/admin' : '/');
     } catch {
       setStatus('error');
       setErrors({ ...newErrors, global: 'Ocurrió un error de red. Intenta más tarde.' });


### PR DESCRIPTION
  - AuthContext centraliza todo el estado de autenticación                                                              
  - Hook useAuth() disponible para cualquier componente sin prop drilling                                               
  - Login redirige a /admin si el rol es admin, o a / si es user                                                        
  - App.jsx limpio — ya no maneja estado de auth directamente  