### PR TITLE
feat: conectar base de datos a TiDB Cloud con soporte SSL

### DIFF
--- a/backend/src/config/database.js
+++ b/backend/src/config/database.js
@@ -8,6 +8,7 @@ const pool = mysql.createPool({
   database: process.env.DB_NAME     || 'rapiti',
   waitForConnections: true,
   connectionLimit: 10,
+  ssl: process.env.DB_SSL === 'true' ? { rejectUnauthorized: true } : undefined,
 });
 
 module.exports = pool;


### PR DESCRIPTION
 Migra la conexión de base de datos a TiDB Cloud (MySQL serverless gratuito) con soporte SSL configurable via DB_SSL   
  env var      