### PR TITLE
fix: mostrar gestión de tiendas solo al rol admin

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,7 +21,7 @@ import AdminTiendas from './views/AdminTiendas';
 import TiendaForm from './views/TiendaForm';
 
 function AppRoutes() {
-  const { isAuth, isAdmin, setShowExpiredModal, showExpiredModal } = useAuth();
+  const { isAuth, isAdmin, rol, setShowExpiredModal, showExpiredModal } = useAuth();
 
   return (
     <div className="min-h-screen bg-[#0a0a0a]">
@@ -41,9 +41,9 @@ function AppRoutes() {
           <Route path="/admin/productos" element={isAdmin ? <AdminProducts /> : <Navigate to="/" replace />} />
           <Route path="/admin/productos/nuevo" element={isAdmin ? <ProductForm /> : <Navigate to="/" replace />} />
           <Route path="/admin/productos/editar/:id" element={isAdmin ? <ProductForm /> : <Navigate to="/" replace />} />
-          <Route path="/admin/tiendas" element={isAdmin ? <AdminTiendas /> : <Navigate to="/" replace />} />
-          <Route path="/admin/tiendas/nueva" element={isAdmin ? <TiendaForm /> : <Navigate to="/" replace />} />
-          <Route path="/admin/tiendas/editar/:id" element={isAdmin ? <TiendaForm /> : <Navigate to="/" replace />} />
+          <Route path="/admin/tiendas" element={rol === 'admin' ? <AdminTiendas /> : <Navigate to="/" replace />} />
+          <Route path="/admin/tiendas/nueva" element={rol === 'admin' ? <TiendaForm /> : <Navigate to="/" replace />} />
+          <Route path="/admin/tiendas/editar/:id" element={rol === 'admin' ? <TiendaForm /> : <Navigate to="/" replace />} />
           <Route path="/tiendas" element={<Tiendas />} />
           <Route path="/tiendas/:id" element={<TiendaDetalle />} />
           <Route path="/para-tiendas" element={<ParaTiendas />} />

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -62,7 +62,7 @@ export function AuthProvider({ children }) {
   }, []);
 
   return (
-    <AuthContext.Provider value={{ isAuth, isAdmin, login, logout, showExpiredModal, setShowExpiredModal }}>
+    <AuthContext.Provider value={{ isAuth, isAdmin, rol, login, logout, showExpiredModal, setShowExpiredModal }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/views/AdminPanel.jsx
+++ b/frontend/src/views/AdminPanel.jsx
@@ -1,6 +1,9 @@
 import { Link } from 'react-router-dom';
+import { useAuth } from '../context/useAuth';
 
 export default function AdminPanel() {
+  const { rol } = useAuth();
+
   return (
     <div className="min-h-[calc(100vh-112px)] px-6 py-12 max-w-4xl mx-auto">
 
@@ -33,15 +36,17 @@ export default function AdminPanel() {
           <p className="text-gray-400 text-sm">Ver y gestionar publicaciones del blog comunitario.</p>
         </Link>
 
-        <Link
-          to="/admin/tiendas"
-          className="bg-neutral-900 border-2 border-neutral-800 hover:border-emerald-500/50 rounded-2xl p-8 transition-all hover:-translate-y-1 focus:outline-none focus-visible:ring-4 focus-visible:ring-emerald-500 animate-fade-in-up"
-          style={{ animationDelay: '0.21s' }}
-        >
-          <div className="text-4xl mb-4">🏪</div>
-          <h2 className="text-white text-xl font-bold mb-1">Tiendas</h2>
-          <p className="text-gray-400 text-sm">Agregar, editar y eliminar tiendas del directorio.</p>
-        </Link>
+        {rol === 'admin' && (
+          <Link
+            to="/admin/tiendas"
+            className="bg-neutral-900 border-2 border-neutral-800 hover:border-emerald-500/50 rounded-2xl p-8 transition-all hover:-translate-y-1 focus:outline-none focus-visible:ring-4 focus-visible:ring-emerald-500 animate-fade-in-up"
+            style={{ animationDelay: '0.21s' }}
+          >
+            <div className="text-4xl mb-4">🏪</div>
+            <h2 className="text-white text-xl font-bold mb-1">Tiendas</h2>
+            <p className="text-gray-400 text-sm">Agregar, editar y eliminar tiendas del directorio.</p>
+          </Link>
+        )}
 
       </div>
     </div>


### PR DESCRIPTION
Restringe el acceso a la gestión de tiendas únicamente al rol admin, ocultando la tarjeta en el panel y protegiendo las rutas del frontend 